### PR TITLE
Added support for 'API Version' parameter for Client initialisation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,13 @@ Use the built-in `default session` to instantiate a globally accessible session.
 from trustpilot import client
 client.default_session.setup(
     api_host="https://api.trustpilot.com",
+    api_version="v1",
     api_key="YOUR_API_KEY",
     api_secret="YOUR_API_SECRET",
     username="YOUR_TRUSTPILOT_BUSINESS_USERNAME",
     password="YOUR_TRUSTPILOT_BUSINESS_PASSWORD"
 )
-response = client.get("/v1/foo/bar")
+response = client.get("/foo/bar")
 ```
 
 You can rely on environment variables for the setup of sessions so
@@ -45,6 +46,7 @@ You can rely on environment variables for the setup of sessions so
 ```bash
 $ env
 TRUSTPILOT_API_HOST=foobar.com
+TRUSTPILOT_API_VERSION=v1
 TRUSTPILOT_API_KEY=foo
 TRUSTPILOT_API_SECRET=bar
 TRUSTPILOT_USERNAME=username
@@ -55,7 +57,7 @@ Will work with the implicit `default_session` and the `TrustpilotSession.setup` 
 
 ```python
 from trustpilot import client
-client.get("/v1/foo/bar")
+client.get("/foo/bar")
 ```
 
 ### Instantiate your own session
@@ -66,12 +68,13 @@ You can create as many sessions as you like, as long as you pass them around you
 from trustpilot import client
 session = client.TrustpilotSession(
     api_host="https://api.trustpilot.com",
+    api_version="v1",
     api_key="YOUR_API_KEY",
     api_secret="YOUR_API_SECRET",
     username="YOUR_TRUSTPILOT_BUSINESS_USERNAME",
     password="YOUR_TRUSTPILOT_BUSINESS_PASSWORD"
 )
-response = session.get("/v1/foo/bar")
+response = session.get("/foo/bar")
 ```
 
 ## Async client
@@ -86,7 +89,7 @@ from trustpilot import async_client
 loop = asyncio.get_event_loop()
 
 async def get_response():
-    response = await async_client.get('/v1/foo/bar')
+    response = await async_client.get('/foo/bar')
     response_json = await response.json()
 
 loop.run_until_complete(get_response())
@@ -101,6 +104,7 @@ loop = asyncio.get_event_loop()
 
 session = async_client.TrustpilotAsyncSession(
     api_host="https://api.trustpilot.com",
+    api_version="v1",
     api_key="YOUR_API_KEY",
     api_secret="YOUR_API_SECRET",
     username="YOUR_TRUSTPILOT_BUSINESS_USERNAME",
@@ -108,7 +112,7 @@ session = async_client.TrustpilotAsyncSession(
 )
 
 async def get_response():
-    response = await session.get('/v1/foo/bar')
+    response = await session.get('/foo/bar')
     response_json = await response.json()
 
 loop.run_until_complete(get_response())
@@ -124,6 +128,7 @@ Usage: trustpilot_api_client [OPTIONS] COMMAND [ARGS]...
 
 Options:
   --host TEXT               host name
+  --version TEST            api version
   --key TEXT                api key
   --secret TEXT             api secret
   --token_issuer_host TEXT  token issuer host name
@@ -146,6 +151,7 @@ In order to use the **-c** option please supply the filename of a JSON in the fo
 ```json
 {
   "TRUSTPILOT_API_HOST": "foo",
+  "TRUSTPILOT_API_VERSION": "v1",
   "TRUSTPILOT_API_KEY": "bar",
   "TRUSTPILOT_API_SECRET": "baz",
   "TRUSTPILOT_USERNAME": "username",

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -35,11 +35,12 @@ def test_async_client_auth_and_get():
             api_key='something',
             api_secret='secret',
             username='username',
-            password='password'
+            password='password',
+            api_version='v1'
         )
 
         async def get_response():
-            response = await session.get('/v1/foo/bar')
+            response = await session.get('/foo/bar')
             response_json = await response.json()
             assert response_json['foo'] == 'foobarbaz'
             assert session.access_token == 'foobarbaz'

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -8,7 +8,6 @@ import json
 
 from trustpilot import client
 
-
 def assert_not_called(mock):
     assert mock.call_count == 0
 
@@ -25,8 +24,9 @@ class TestCliMethods(unittest.TestCase):
         self.token_issuer_host = "https://hostname.com"
         self.username = "username"
         self.password = "password"
+        self.api_version='v1'
 
-        self.request_url = "/v1/this/1"
+        self.request_url = "/this/1"
 
         self.exp_headers = {
             'apikey': 'secret_api_key',
@@ -41,7 +41,8 @@ class TestCliMethods(unittest.TestCase):
             token_issuer_path=self.token_issuer_path,
             token_issuer_host=self.token_issuer_host,
             username=self.username,
-            password=self.password
+            password=self.password,
+            api_version=self.api_version
         )
         return session
 
@@ -54,7 +55,8 @@ class TestCliMethods(unittest.TestCase):
             access_token_path=self.token_issuer_path,
             token_issuer_host=self.token_issuer_host,
             username=self.username,
-            password=self.password
+            password=self.password,
+            api_version=self.api_version
         )
         for attr in ["api_key",
                      "api_secret",
@@ -62,7 +64,8 @@ class TestCliMethods(unittest.TestCase):
                      "token_issuer_path",
                      "token_issuer_host",
                      "username",
-                     "password"]:
+                     "password",
+                     "api_version"]:
             assert getattr(self, attr) == getattr(session, attr)
 
     @responses.activate
@@ -129,6 +132,7 @@ class TestCliMethods(unittest.TestCase):
                     body="foo",
                     status=401
             )
+            
             session = self.session
             response = session.get(self.request_url)
 

--- a/trustpilot/async_client.py
+++ b/trustpilot/async_client.py
@@ -26,13 +26,14 @@ class TrustpilotAsyncSession():
         self.setup(**kwargs)
         self.headers = {}
 
-    def setup(self, api_host=None, api_key=None, api_secret=None,
+    def setup(self, api_host=None, api_version=None, api_key=None, api_secret=None,
               username=None, password=None,
               access_token=None, token_issuer_path=None,
               token_issuer_host=None, **kwargs):
 
-        self.api_host = api_host or environ.get(
-            'TRUSTPILOT_API_HOST', 'https://api.trustpilot.com')
+        self.api_version = api_version or environ.get('TRUSTPILOT_API_VERSION', 'v1')
+        self.api_host = api_host or 
+                            environ.get('TRUSTPILOT_API_HOST', 'https://api.trustpilot.com/{version}'.format(version=self.api_version))
         self.token_issuer_host = token_issuer_host or self.api_host
         self.access_token = access_token
         self.token_issuer_path = token_issuer_path or environ.get(

--- a/trustpilot/async_client.py
+++ b/trustpilot/async_client.py
@@ -32,8 +32,7 @@ class TrustpilotAsyncSession():
               token_issuer_host=None, **kwargs):
 
         self.api_version = api_version or environ.get('TRUSTPILOT_API_VERSION', 'v1')
-        self.api_host = api_host or 
-                            environ.get('TRUSTPILOT_API_HOST', 'https://api.trustpilot.com/{version}'.format(version=self.api_version))
+        self.api_host = api_host or environ.get('TRUSTPILOT_API_HOST', 'https://api.trustpilot.com')
         self.token_issuer_host = token_issuer_host or self.api_host
         self.access_token = access_token
         self.token_issuer_path = token_issuer_path or environ.get(
@@ -72,7 +71,7 @@ class TrustpilotAsyncSession():
         if method not in self.__SUPPORTED_HTTP_METHODS:
             raise RuntimeError("Http method {} not supported".format(method))
         if not any(prefix in url for prefix in ["http://", "https://"]):
-            url = "{}{}".format(self.api_host, url)
+            url = "{}/{}{}".format(self.api_host.rstrip('/'), self.api_version, url)
 
         async with aiohttp.ClientSession(headers=self.headers) as session:
             http_method = getattr(session, method)

--- a/trustpilot/auth.py
+++ b/trustpilot/auth.py
@@ -21,8 +21,9 @@ def get_user_agent():
 
 
 def create_access_token_request_params(session):
-    url = "{token_issuer_host}/{token_issuer_path}".format(
-        token_issuer_host=session.token_issuer_host,
+    url = "{token_issuer_host}/{api_version}/{token_issuer_path}".format(
+        token_issuer_host=session.token_issuer_host.rstrip('/'),
+        api_version=session.api_version.rstrip('/'),
         token_issuer_path=session.token_issuer_path
     )
     data = {

--- a/trustpilot/auth.py
+++ b/trustpilot/auth.py
@@ -21,7 +21,7 @@ def get_user_agent():
 
 
 def create_access_token_request_params(session):
-    url = "{token_issuer_host}/v1/{token_issuer_path}".format(
+    url = "{token_issuer_host}/{token_issuer_path}".format(
         token_issuer_host=session.token_issuer_host,
         token_issuer_path=session.token_issuer_path
     )

--- a/trustpilot/cli.py
+++ b/trustpilot/cli.py
@@ -41,6 +41,8 @@ def format_response(response):
 @click.pass_context
 @click.option('--host', type=str, help="host name",
               envvar='TRUSTPILOT_API_HOST')
+@click.option('--version', type=str, help="api version (e.g. v1)",
+              envvar='TRUSTPILOT_API_VERSION')
 @click.option('--key', type=str, help="api key",
               envvar='TRUSTPILOT_API_KEY')
 @click.option('--secret', type=str, help="api secret",
@@ -111,6 +113,8 @@ def cli(ctx, **kwargs):
         client.create_session(
             api_host=kwargs.pop("host") or values_dict.get(
                 "TRUSTPILOT_API_HOST") or "https://api.tp-staging.com",
+            api_version=kwargs.pop("version") or values_dict.get(
+                "TRUSTPILOT_API_VERSION") or "v1",
             api_key=kwargs.pop("key") or values_dict["TRUSTPILOT_API_KEY"],
             api_secret=(kwargs.pop("secret")
                         or values_dict.get("TRUSTPILOT_API_SECRET", None)),

--- a/trustpilot/client.py
+++ b/trustpilot/client.py
@@ -32,12 +32,13 @@ class TrustpilotSession(requests.Session):
         self._post_hooks = []
         self.auth = self._pre_request_callback
 
-    def setup(self, api_host=None, api_key=None, api_secret=None,
+    def setup(self, api_host=None, api_version=None, api_key=None, api_secret=None,
               username=None, password=None,
               access_token=None, token_issuer_path=None,
               token_issuer_host=None, **kwargs):
-
-        self.api_host = api_host or environ.get('TRUSTPILOT_API_HOST', 'https://api.trustpilot.com')
+        
+        self.api_version = api_version or environ.get('TRUSTPILOT_API_VERSION', 'v1')
+        self.api_host = api_host or environ.get('TRUSTPILOT_API_HOST', 'https://api.trustpilot.com/{version}'.format(version=self.api_version))
         self.token_issuer_host = token_issuer_host or self.api_host
         self.access_token = access_token
         self.token_issuer_path = token_issuer_path or environ.get(
@@ -117,7 +118,7 @@ def get_session():
     return default_session
 
 
-def create_session(api_host=None, api_key=None, api_secret=None,
+def create_session(api_host=None, api_version=None, api_key=None, api_secret=None,
                    username=None, password=None,
                    access_token_path=None,
                    token_issuer_host=None, access_token=None):
@@ -127,6 +128,7 @@ def create_session(api_host=None, api_key=None, api_secret=None,
 
     default_session.setup(
         api_host=api_host,
+        api_version=api_version,
         api_key=api_key,
         api_secret=api_secret,
         access_token=access_token,

--- a/trustpilot/client.py
+++ b/trustpilot/client.py
@@ -38,7 +38,7 @@ class TrustpilotSession(requests.Session):
               token_issuer_host=None, **kwargs):
         
         self.api_version = api_version or environ.get('TRUSTPILOT_API_VERSION', 'v1')
-        self.api_host = api_host or environ.get('TRUSTPILOT_API_HOST', 'https://api.trustpilot.com/{version}'.format(version=self.api_version))
+        self.api_host = api_host or environ.get('TRUSTPILOT_API_HOST', 'https://api.trustpilot.com')
         self.token_issuer_host = token_issuer_host or self.api_host
         self.access_token = access_token
         self.token_issuer_path = token_issuer_path or environ.get(
@@ -107,7 +107,7 @@ class TrustpilotSession(requests.Session):
 
     def request(self, method, url, **kwargs):  # pylint: disable=W0221
         if not any(prefix in url for prefix in ["http://", "https://"]):
-            url = "{}{}".format(self.api_host, url)
+            url = "{}/{}{}".format(self.api_host.rstrip('/'), self.api_version, url)
         return super(TrustpilotSession, self).request(method, url, **kwargs)
 
 


### PR DESCRIPTION
This PR adds support for specifying the API version you wish to use when connecting to the Trustpilot API. The format for this parameter is `v<n>` where `<n>` is the version you wish to use (e.g. `v1`, `v2` etc.)

Given that the Trustpilot API remains at `v1` at the time of writing, this is the default if `api_version` is not specified. 

The motivation behind this PR is to prevent the need to include the API version in subsequent URLs when using the client to call the Trustpilot API.