### PR TITLE
Don't pin to a fixed version of requests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ with open('HISTORY.rst') as history_file:
 
 requirements = [
     'Click==6.7',
-    'requests==2.20.0',
+    'requests>=2.20.0',
 ]
 
 test_requirements = [


### PR DESCRIPTION
Updated to >= so users can track higher versions of requests without warnings.