### PR TITLE
Authenticate on 401 _and_ 403 responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ _(for **full usage documentation** checkout [docs](https://github.com/trustpilot
 ```python
 from trustpilot import client
 client.default_session.setup(
-    api_host="https://api.trustpilot.com"
-    api_key="YOUR_API_KEY"
+    api_host="https://api.trustpilot.com",
+    api_key="YOUR_API_KEY",
 )
 response = client.get("/foo/bar")
 status_code = response.status_code

--- a/trustpilot/async_client.py
+++ b/trustpilot/async_client.py
@@ -88,7 +88,7 @@ class TrustpilotAsyncSession:
         async with aiohttp.ClientSession(headers=self.headers) as session:
             http_method = getattr(session, method)
             async with http_method(cleaned_url, *args, **kwargs) as response:
-                if response.status == 401:
+                if response.status in (401, 403):
                     authenticate_and_retry = True
                 else:
                     yield response

--- a/trustpilot/client.py
+++ b/trustpilot/client.py
@@ -112,7 +112,7 @@ class TrustpilotSession(requests.Session):
         req = response.request
         retry = getattr(req, "authentication_retry", True)
 
-        if retry and response.status_code == requests.codes.unauthorized:
+        if retry and response.status_code in (requests.codes.unauthorized, requests.codes.forbidden):
             logger.debug(
                 {"message": "reauthenticating and retrying once", "url": req.url}
             )


### PR DESCRIPTION
The Trustpilot API may return an HTTP status of `403` which wasn’t being automatically authenticated.