### PR TITLE
default to the grant type: client_credentials

### DIFF
--- a/trustpilot/auth.py
+++ b/trustpilot/auth.py
@@ -23,7 +23,9 @@ def create_access_token_request_params(session):
         token_issuer_path=session.token_issuer_path,
     )
 
-    data = {}
+    data = {
+        'grant_type': 'client_credentials'
+        }
 
     if session.username and session.password:
         data = {


### PR DESCRIPTION
### What ⁉️
Set grant_type to client_credentials as default if no username and password is set.
as seen here: https://documentation-apidocumentation.trustpilot.com/authentication#client-credentials

### Why ⁉️
 This allows for authentication without a user. Using only key and secret. 

### How ⁉️
Update the default payload from an empty body 

### How to review and test 📱
Using only api_key and api_secret when using TrustpilotSession now gives a 200 response. 
`
tp_session = tp.TrustpilotSession(
    api_host='https://api.trustpilot.com',
    api_key='key',
    api_secret = 'secret',
    )
`
</br>

### Checklist ✅
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests are passing locally
